### PR TITLE
run multiple options in one run, keep compiled exes around, delete th…

### DIFF
--- a/compile-cilk.sh
+++ b/compile-cilk.sh
@@ -46,7 +46,30 @@ if [ $force == 0 ]; then
 	exit 0
     fi
 fi
-./testCilk.sh -${model} -x=0 -w=0 ${benchmark}
+# convert our suffix name into a switch for testCilk compilation
+case $model in
+    pnnt)
+	modelswitch=t
+	;;
+    pnnuf)
+	modelswitch=uf
+	;;
+    pnnlf)
+	modelswitch=f
+	;;
+    pnnef)
+	modelswitch=ef
+	;;
+    pnns)
+	modelswitch=s
+	;;
+    *)
+	echo "Bad model"
+	exit -1
+	;;
+esac
+# run compile command
+./testCilk.sh -${modelswitch} -x=0 -w=0 ${benchmark}
 status=$?
 if [ $status == 0 ]; then
     echo "Saving to ${target}"

--- a/rm-all-exes.sh
+++ b/rm-all-exes.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/bash
+
+# any test executables?
+cn=`find cilk5 -name "*.*" -type f -executable -print | wc -l`
+pb=`find pbbs_v2/ -name "*.*" -type f -executable -print | wc -l`
+if [ "$cn$pb" == "00" ]; then
+    echo "Nothing to delete"
+    exit 0
+fi
+# list them
+find cilk5 -name "*.*" -type f -executable -print
+find pbbs_v2/ -name "*.*" -type f -executable -print
+read -p "Please confirm deletion (yes/no): " ans
+if [ "$ans" == "yes" ]; then
+    # delete them
+    find cilk5 -name "*.*" -type f -executable -exec /bin/rm "{}" \;
+    find pbbs_v2/ -name "*.*" -type f -executable -exec /bin/rm "{}" \;
+    echo "All removed"
+else
+    echo "Nothing done"
+fi
+
+    


### PR DESCRIPTION
modified testBenchmark so you can put multiple options on the command line and they are all run.
fixed compile-cilk.sh to deal with our new naming scheme
rm-all-exe will show all executables and prompt user to delete if they want to.

We might want to record the suffix in the output file.  